### PR TITLE
debian-packaging: Add support for older (jessie and before) debian releases

### DIFF
--- a/debian-packaging/src/repository/filesystem.rs
+++ b/debian-packaging/src/repository/filesystem.rs
@@ -65,10 +65,13 @@ impl RepositoryRootReader for FilesystemRepositoryReader {
         path: &str,
     ) -> Result<Box<dyn ReleaseReader>> {
         let distribution_path = path.trim_matches('/').to_string();
-        let release_path = format!("{}/InRelease", distribution_path);
+        let inrelease_path = format!("{}/InRelease", distribution_path);
+        let release_path = format!("{}/Release", distribution_path);
         let distribution_dir = self.root_dir.join(&distribution_path);
 
-        let release = self.fetch_inrelease(&release_path).await?;
+        let release = self
+            .fetch_inrelease_or_release(&inrelease_path, &release_path)
+            .await?;
 
         let fetch_compression = Compression::default_preferred_order()
             .next()

--- a/debian-packaging/src/repository/http.rs
+++ b/debian-packaging/src/repository/http.rs
@@ -131,7 +131,8 @@ impl RepositoryRootReader for HttpRepositoryClient {
         path: &str,
     ) -> Result<Box<dyn ReleaseReader>> {
         let distribution_path = path.trim_matches('/').to_string();
-        let release_path = join_path(&distribution_path, "InRelease");
+        let inrelease_path = join_path(&distribution_path, "InRelease");
+        let release_path = join_path(&distribution_path, "Release");
         let mut root_url = self.root_url.join(&distribution_path)?;
 
         // Trailing URLs are significant to the Url type when we .join(). So ensure
@@ -140,7 +141,9 @@ impl RepositoryRootReader for HttpRepositoryClient {
             root_url.set_path(&format!("{}/", root_url.path()));
         }
 
-        let release = self.fetch_inrelease(&release_path).await?;
+        let release = self
+            .fetch_inrelease_or_release(&inrelease_path, &release_path)
+            .await?;
 
         let fetch_compression = Compression::default_preferred_order()
             .next()


### PR DESCRIPTION


Older debian release do not have the fancy new InRelease file, so fall back to using Release file if the former is missing not found