### PR TITLE
debian-packaging: fix deb builder data dir tar entry type

### DIFF
--- a/debian-packaging/src/deb/builder.rs
+++ b/debian-packaging/src/deb/builder.rs
@@ -336,6 +336,7 @@ pub fn write_deb_tar<W: Write>(writer: W, files: &FileManifest, mtime: u64) -> R
     header.set_path(Path::new("./"))?;
     header.set_mode(0o755);
     header.set_size(0);
+    header.set_entry_type(tar::EntryType::Directory);
     header.set_cksum();
     builder.append(&header, &*vec![])?;
 
@@ -345,6 +346,7 @@ pub fn write_deb_tar<W: Write>(writer: W, files: &FileManifest, mtime: u64) -> R
         set_header_path(&mut builder, &mut header, &directory, true)?;
         header.set_mode(0o755);
         header.set_size(0);
+        header.set_entry_type(tar::EntryType::Directory);
         header.set_cksum();
         builder.append(&header, &*vec![])?;
     }


### PR DESCRIPTION
These default to file, rather than directory, which tends to conflict with other already installed packages that treat '/' as a directory.