### PR TITLE
Fix build without http feature

### DIFF
--- a/debian-packaging/src/error.rs
+++ b/debian-packaging/src/error.rs
@@ -12,7 +12,6 @@ pub enum DebianError {
     #[error("file manifest error: {0}")]
     FileManifestError(#[from] FileManifestError),
 
-    #[cfg(feature = "http")]
     #[error("URL error: {0:?}")]
     Url(#[from] url::ParseError),
 


### PR DESCRIPTION
Currently, if you build without the http feature, it fails to build:

```
error[E0277]: `?` couldn't convert the error to `DebianError`
    --> /home/russell/linux-packaging-rs/debian-packaging/src/repository/mod.rs:1115:38
     |
1115 |         let url = url::Url::parse(&s)?;
     |                                      ^ the trait `From<url::ParseError>` is not implemented for `DebianError`
     |
     = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
     = help: the following other types implement trait `From<T>`:
               <DebianError as From<FileManifestError>>
               <DebianError as From<MailParseError>>
               <DebianError as From<pgp::errors::Error>>
               <DebianError as From<std::io::Error>>
               <DebianError as From<std::num::ParseIntError>>
     = note: required for `std::result::Result<Box<dyn RepositoryWriter>, DebianError>` to implement `FromResidual<std::result::Result<Infallible, url::ParseError>>`

error[E0277]: `?` couldn't convert the error to `DebianError`
    --> /home/russell/linux-packaging-rs/debian-packaging/src/repository/mod.rs:1087:38
     |
1083 | pub fn reader_from_str(s: impl ToString) -> Result<Box<dyn RepositoryRootReader>> {
     |                                             ------------------------------------- expected `DebianError` because of this
...
1087 |         let url = url::Url::parse(&s)?;
     |                                      ^ the trait `From<url::ParseError>` is not implemented for `DebianError`
     |
     = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
     = help: the following other types implement trait `From<T>`:
               <DebianError as From<FileManifestError>>
               <DebianError as From<MailParseError>>
               <DebianError as From<pgp::errors::Error>>
               <DebianError as From<std::io::Error>>
               <DebianError as From<std::num::ParseIntError>>
     = note: required for `std::result::Result<Box<dyn RepositoryRootReader>, DebianError>` to implement `FromResidual<std::result::Result<Infallible, url::ParseError>>`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `debian-packaging` (lib) due to 2 previous errors
```

this is the easiest solution. Maybe it would be better to somehow not depend on `url` if http is off, but that seems probably not worth the work for now. 