### PR TITLE
Migrate from xz2 to liblzma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,19 +207,14 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.17"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
+checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
 dependencies = [
- "bzip2",
- "flate2",
- "futures-core",
+ "compression-codecs",
+ "compression-core",
  "futures-io",
- "memchr",
  "pin-project-lite",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -559,23 +554,11 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -707,6 +690,27 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+dependencies = [
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -972,6 +976,7 @@ dependencies = [
  "hex",
  "indoc",
  "libflate",
+ "liblzma",
  "mailparse",
  "md-5 0.10.6",
  "once_cell",
@@ -996,7 +1001,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
- "xz2",
  "zstd",
 ]
 
@@ -1354,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1987,6 +1991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2024,26 @@ dependencies = [
  "core2",
  "hashbrown 0.14.5",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "liblzma"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2056,6 +2086,7 @@ dependencies = [
  "futures-util",
  "iced-x86",
  "indoc",
+ "liblzma",
  "num_cpus",
  "object",
  "once_cell",
@@ -2066,7 +2097,6 @@ dependencies = [
  "tokio",
  "trycmd",
  "url",
- "xz2",
  "zstd",
 ]
 
@@ -2093,17 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -2167,11 +2186,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3456,6 +3476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,15 +4360,6 @@ name = "xml-rs"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "zerocopy"

--- a/debian-packaging/Cargo.toml
+++ b/debian-packaging/Cargo.toml
@@ -22,6 +22,7 @@ digest = "0.10.7"
 futures = "0.3.31"
 hex = "0.4.3"
 libflate = "2.1.0"
+liblzma = { version = "0.4.5", features = ["static"] }
 mailparse = "0.15.0"
 md-5 = "0.10.6"
 once_cell = "1.18.0"
@@ -42,7 +43,6 @@ tar = "0.4.43"
 thiserror = "1.0.66"
 tokio = { version = "1.41.0", default-features = false, optional = true }
 url = "2.5.2"
-xz2 = { version = "0.1.7", features = ["static"] }
 zstd = "0.13.2"
 
 [dependencies.async-compression]

--- a/debian-packaging/src/deb/mod.rs
+++ b/debian-packaging/src/deb/mod.rs
@@ -54,7 +54,7 @@ impl DebCompression {
                 encoder.finish().into_result()?;
             }
             Self::Xz(level) => {
-                let mut encoder = xz2::write::XzEncoder::new(buffer, *level);
+                let mut encoder = liblzma::write::XzEncoder::new(buffer, *level);
                 std::io::copy(reader, &mut encoder)?;
                 buffer = encoder.finish()?;
             }

--- a/debian-packaging/src/deb/reader.rs
+++ b/debian-packaging/src/deb/reader.rs
@@ -20,7 +20,7 @@ fn reader_from_filename(extension: &str, data: std::io::Cursor<Vec<u8>>) -> Resu
     match extension {
         "" => Ok(Box::new(data)),
         ".gz" => Ok(Box::new(libflate::gzip::Decoder::new(data)?)),
-        ".xz" => Ok(Box::new(xz2::read::XzDecoder::new(data))),
+        ".xz" => Ok(Box::new(liblzma::read::XzDecoder::new(data))),
         ".zst" => Ok(Box::new(zstd::Decoder::new(data)?)),
         _ => Err(DebianError::DebUnknownCompression(extension.to_string())),
     }

--- a/linux-package-analyzer/Cargo.toml
+++ b/linux-package-analyzer/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 iced-x86 = "1.21.0"
 indoc = "2.0.5"
+liblzma = { version = "0.4.5", features = ["static"] }
 num_cpus = "1.16.0"
 object = "0.36.5"
 once_cell = "1.20.2"
@@ -31,7 +32,6 @@ rusqlite = { version = "0.29.0", features = ["bundled"] }
 symbolic-demangle = "12.12.0"
 tokio = { version = "1.41.0", features = ["full"] }
 url = "2.5.2"
-xz2 = { version = "0.1.7", features = ["static"] }
 zstd = "0.13.2"
 
 [dependencies.debian-packaging]


### PR DESCRIPTION
This replaces the [`xz2`](https://docs.rs/xz2) dependency with its fork [`liblzma`](https://docs.rs/liblzma), which appears to work as a drop-in replacement. From [what I've read](https://github.com/apache/datafusion/issues/15342#issuecomment-3095922964), the circumstances surrounding this fork are a bit unfortunate, but the practical implication is that this PR fixes Cargo's dependency resolution giving up when I attempt to add a `debian-packaging` dependency to my project.